### PR TITLE
mysql password option should not have a space

### DIFF
--- a/lib/brancher/auto_copying.rb
+++ b/lib/brancher/auto_copying.rb
@@ -43,11 +43,11 @@ module Brancher
 
         cmd = ["mysqldump", "-u", config[:username]]
         cmd.concat(["-h", config[:host]]) if config[:host].present?
-        cmd.concat(["-p", config[:password]]) if config[:password].present?
+        cmd.concat(["-p#{config[:password]}"]) if config[:password].present?
         cmd << original_database_name
         cmd.concat(["|", "mysql", "-u", config[:username]])
         cmd.concat(["-h", config[:host]]) if config[:host].present?
-        cmd.concat(["-p", config[:password]]) if config[:password].present?
+        cmd.concat(["-p#{config[:password]}"]) if config[:password].present?
         cmd << database_name
         system(cmd.join(" "))
       end


### PR DESCRIPTION
http://dev.mysql.com/doc/refman/5.6/en/mysql-command-options.html#option_mysql_password

As indicated in the mysql documentation "If you use the short option form (-p), you _cannot_ have a space between the option and the password."
