### PR TITLE
fix not use except_branches option when rake tasks such as rake db:create

### DIFF
--- a/lib/brancher/railtie.rb
+++ b/lib/brancher/railtie.rb
@@ -10,9 +10,16 @@ module Brancher
     rake_tasks do
       namespace :db do
         task :load_config do
+          require_environment!
           DatabaseRenameService.rename!(ActiveRecord::Base.configurations)
         end
       end
+    end
+
+    def require_environment!
+      return unless defined? Rails
+      environemnt = "#{Rails.root}/config/environments/#{Rails.env}.rb"
+      require environemnt if File.exists?(environemnt)
     end
   end
 end


### PR DESCRIPTION
Doesn't run `except_branches` option  when I set `config.except_branches << 'master'` on master branch and I run `rake db:create`.
I think that the rake task doesn't load environment file. I guess some database tasks don't have `:environment` as below.
https://github.com/rails/docrails/blob/master/activerecord/lib/active_record/railties/databases.rake#L16
### my environments
- ruby 2.2.0
- rails 4.2.3

```
# Rails.root/config/environments/development.rb

Rails.application.configure do
  ...
end

Brancher.configure do |c|
  # if branch is "master" or "develop", database name has no suffix.
  c.except_branches << "master"

  # if auto_copy is true and database does not exist,
  # copy database from no suffix name database to suffixed name one.
  c.auto_copy = true
end
```
