### PR TITLE
Cap database name length

### DIFF
--- a/lib/brancher.rb
+++ b/lib/brancher.rb
@@ -6,6 +6,7 @@ module Brancher
   include ActiveSupport::Configurable
   config.except_branches ||= []
   config.auto_copy ||= false
+  config.max_database_name_length ||= 63
 end
 
 require "brancher/database_configuration_renaming"

--- a/lib/brancher/auto_copying.rb
+++ b/lib/brancher/auto_copying.rb
@@ -24,11 +24,10 @@ module Brancher
       end
 
       def auto_copy
-        suffix = Brancher::DatabaseRenameService.suffix
-        return unless suffix
+        return if config[:database] == config[:original_database]
 
         database_name = config[:database]
-        original_database_name = database_name.gsub(Regexp.new(suffix), "")
+        original_database_name = config[:original_database]
 
         case config[:adapter]
         when /mysql/

--- a/lib/brancher/database_rename_service.rb
+++ b/lib/brancher/database_rename_service.rb
@@ -18,7 +18,7 @@ module Brancher
       database_name = database.gsub(%r{#{database_extname}$}) { "" }
       database_name += suffix unless database_name =~ %r{#{suffix}$}
       database_name += database_extname
-      database_name = database_name.slice(0,Brancher.config.max_database_name_length-22) + [Digest::MD5.digest(database_name)].pack("m0").slice(0,22) if database_name.length > Brancher.config.max_database_name_length
+      database_name = database_name.slice(0,Brancher.config.max_database_name_length-22) + [Digest::MD5.digest(database_name)].pack("m0").slice(0,22).gsub(/[^\w]/, '_') if database_name.length > Brancher.config.max_database_name_length
       database_name
     end
 

--- a/lib/brancher/database_rename_service.rb
+++ b/lib/brancher/database_rename_service.rb
@@ -7,15 +7,15 @@ module Brancher
     def rename!(configurations)
       configuration = configurations[env]
       configuration["original_database"] = configuration["database"]
-      configuration["database"] = database_name(configuration)
+      configuration["database"] = database_name_with_suffix(configuration["database"])
       configurations
     end
 
     private
 
-    def database_name_with_suffix(configuration)
-      database_extname = File.extname(configuration["database"])
-      database_name = configuration["database"].gsub(%r{#{database_extname}$}) { "" }
+    def database_name_with_suffix(database)
+      database_extname = File.extname(database)
+      database_name = database.gsub(%r{#{database_extname}$}) { "" }
       database_name += suffix unless database_name =~ %r{#{suffix}$}
       database_name += database_extname
       database_name = database_name.slice(0,Brancher.config.max_database_name_length-22) + [Digest::MD5.digest(database_name)].pack("m0").slice(0,22) if database_name.length > Brancher.config.max_database_name_length
@@ -23,9 +23,7 @@ module Brancher
     end
 
     def suffix
-      return nil if current_branch.blank?
-      return nil if Brancher.config.except_branches.include?(current_branch)
-
+      return nil if current_branch.blank? || Brancher.config.except_branches.include?(current_branch)
       "_#{current_branch}"
     end
 

--- a/lib/brancher/database_rename_service.rb
+++ b/lib/brancher/database_rename_service.rb
@@ -9,7 +9,7 @@ module Brancher
       database_extname = File.extname(configuration["database"])
       database_name = configuration["database"].gsub(%r{#{database_extname}$}) { "" }
       database_name += suffix unless database_name =~ %r{#{suffix}$}
-      configuration["database"] = database_name + database_extname
+      configuration["database"] = cap_length(database_name + database_extname)
       configurations
     end
 
@@ -21,6 +21,12 @@ module Brancher
     end
 
     private
+
+    def cap_length(database_full_name)
+      max_length = 63
+      database_full_name = database_full_name.slice(0,max_length-22) + [Digest::MD5.digest(database_full_name)].pack("m0").slice(0,22) if database_full_name.length > max_length
+      database_full_name
+    end
 
     def env
       Rails.env

--- a/lib/brancher/database_rename_service.rb
+++ b/lib/brancher/database_rename_service.rb
@@ -18,7 +18,7 @@ module Brancher
       database_name = database.gsub(%r{#{database_extname}$}) { "" }
       database_name += suffix unless database_name =~ %r{#{suffix}$}
       database_name += database_extname
-      database_name = database_name.slice(0,Brancher.config.max_database_name_length-22) + [Digest::MD5.digest(database_name)].pack("m0").slice(0,22).gsub(/[^\w]/, '_') if database_name.length > Brancher.config.max_database_name_length
+      database_name = database_name.slice(0,Brancher.config.max_database_name_length-22) + [Digest::MD5.digest(database_name)].pack("m0").slice(0,22).gsub(/[^\w]/, '_').downcase if database_name.length > Brancher.config.max_database_name_length
       database_name
     end
 

--- a/lib/brancher/database_rename_service.rb
+++ b/lib/brancher/database_rename_service.rb
@@ -6,9 +6,12 @@ module Brancher
 
     def rename!(configurations)
       configuration = configurations[env]
+      configuration["original_database"] = configuration["database"]
       configuration["database"] = database_name(configuration)
       configurations
     end
+
+    private
 
     def database_name_with_suffix(configuration)
       database_extname = File.extname(configuration["database"])
@@ -18,8 +21,6 @@ module Brancher
       database_name = database_name.slice(0,Brancher.config.max_database_name_length-22) + [Digest::MD5.digest(database_name)].pack("m0").slice(0,22) if database_name.length > Brancher.config.max_database_name_length
       database_name
     end
-
-    private
 
     def suffix
       return nil if current_branch.blank?

--- a/lib/brancher/database_rename_service.rb
+++ b/lib/brancher/database_rename_service.rb
@@ -6,25 +6,26 @@ module Brancher
 
     def rename!(configurations)
       configuration = configurations[env]
+      configuration["database"] = database_name(configuration)
+      configurations
+    end
+
+    def database_name_with_suffix(configuration)
       database_extname = File.extname(configuration["database"])
       database_name = configuration["database"].gsub(%r{#{database_extname}$}) { "" }
       database_name += suffix unless database_name =~ %r{#{suffix}$}
-      configuration["database"] = cap_length(database_name + database_extname)
-      configurations
+      database_name += database_extname
+      database_name = database_name.slice(0,Brancher.config.max_database_name_length-22) + [Digest::MD5.digest(database_name)].pack("m0").slice(0,22) if database_name.length > Brancher.config.max_database_name_length
+      database_name
     end
+
+    private
 
     def suffix
       return nil if current_branch.blank?
       return nil if Brancher.config.except_branches.include?(current_branch)
 
       "_#{current_branch}"
-    end
-
-    private
-
-    def cap_length(database_name)
-      database_name = database_name.slice(0,Brancher.config.max_database_name_length-22) + [Digest::MD5.digest(database_name)].pack("m0").slice(0,22) if database_name.length > Brancher.config.max_database_name_length
-      database_name
     end
 
     def env

--- a/lib/brancher/database_rename_service.rb
+++ b/lib/brancher/database_rename_service.rb
@@ -22,10 +22,9 @@ module Brancher
 
     private
 
-    def cap_length(database_full_name)
-      max_length = 63
-      database_full_name = database_full_name.slice(0,max_length-22) + [Digest::MD5.digest(database_full_name)].pack("m0").slice(0,22) if database_full_name.length > max_length
-      database_full_name
+    def cap_length(database_name)
+      database_name = database_name.slice(0,Brancher.config.max_database_name_length-22) + [Digest::MD5.digest(database_name)].pack("m0").slice(0,22) if database_name.length > Brancher.config.max_database_name_length
+      database_name
     end
 
     def env

--- a/spec/brancher/database_rename_service_spec.rb
+++ b/spec/brancher/database_rename_service_spec.rb
@@ -92,7 +92,7 @@ describe Brancher::DatabaseRenameService do
       end
 
       let(:new_database_name) do
-        "this_is_a_very_long_sample_app_developmen#{[Digest::MD5.digest("#{database_name}_#{branch}")].pack('m0').slice(0,22)}"
+        "this_is_a_very_long_sample_app_developmen#{[Digest::MD5.digest("#{database_name}_#{branch}")].pack('m0').slice(0,22).gsub(/[^\w]/, '_')}"
       end
 
       it { is_expected.to eq new_configurations }

--- a/spec/brancher/database_rename_service_spec.rb
+++ b/spec/brancher/database_rename_service_spec.rb
@@ -92,7 +92,7 @@ describe Brancher::DatabaseRenameService do
       end
 
       let(:new_database_name) do
-        "this_is_a_very_long_sample_app_developmen#{[Digest::MD5.digest("#{database_name}_#{branch}")].pack('m0').slice(0,22).gsub(/[^\w]/, '_')}"
+        "this_is_a_very_long_sample_app_developmen#{[Digest::MD5.digest("#{database_name}_#{branch}")].pack('m0').slice(0,22).gsub(/[^\w]/, '_').downcase}"
       end
 
       it { is_expected.to eq new_configurations }

--- a/spec/brancher/database_rename_service_spec.rb
+++ b/spec/brancher/database_rename_service_spec.rb
@@ -46,7 +46,8 @@ describe Brancher::DatabaseRenameService do
           "adapter" => adapter,
           "pool" => 5,
           "timeout" => 5000,
-          "database" => new_database_name
+          "database" => new_database_name,
+          "original_database" => database_name
         }
       }
     end
@@ -76,6 +77,22 @@ describe Brancher::DatabaseRenameService do
     context "when a database has already renamed" do
       let(:database_name) do
         "db/sample_app_development_#{branch}.sqlite3"
+      end
+
+      it { is_expected.to eq new_configurations }
+    end
+
+    context "when the database name is longer than max_database_name_length" do
+      let(:adapter) do
+        "mysql2"
+      end
+
+      let(:database_name) do
+        "this_is_a_very_long_sample_app_development_database_name_that_exceeds_the_default_set_max_database_name_length"
+      end
+
+      let(:new_database_name) do
+        "this_is_a_very_long_sample_app_developmen#{[Digest::MD5.digest("#{database_name}_#{branch}")].pack('m0').slice(0,22)}"
       end
 
       it { is_expected.to eq new_configurations }


### PR DESCRIPTION
Both MySQL and Postgres have a default max database name character length of 63 characters, if a branch name is longer than this the auto_copy operations and attempts to connect to the configured database will fail.  Any names under 63 characters are not changed so no existing functionality is lost.

There seems to be a number of methods to shorten the name, but adding a unique id should prevent most conflicts.  Since the id is generated as a Base64 MD5 hash key from the new full database name the key is not guaranteed unique, additionally the key will have all non-word characters converted to underscores and all characters converted to downcast to ensure compatibility with all databases and configurations.  Even with these limitations, the chances of a conflict in names should be very slim considering the key is appended to a shortened version of the original database name.  If anyone has any recommendations for a better method to handle this I'd be happy to implement it.
