### PR TITLE
Support multiple databases

### DIFF
--- a/lib/brancher.rb
+++ b/lib/brancher.rb
@@ -10,6 +10,7 @@ module Brancher
 end
 
 require "brancher/database_configuration_renaming"
+require "brancher/multiple_database_configuration_renaming"
 require "brancher/database_rename_service"
 require "brancher/auto_copying"
 require "brancher/railtie"

--- a/lib/brancher/auto_copying.rb
+++ b/lib/brancher/auto_copying.rb
@@ -38,7 +38,7 @@ module Brancher
       end
 
       def mysql_copy(original_database_name, database_name)
-        system("bundle", "exec", "rake", "db:create")
+        ActiveRecord::Tasks::DatabaseTasks.create(config.with_indifferent_access)
 
         cmd = ["mysqldump", "-u", config[:username]]
         cmd.concat(["-h", config[:host]]) if config[:host].present?

--- a/lib/brancher/database_rename_service.rb
+++ b/lib/brancher/database_rename_service.rb
@@ -4,8 +4,8 @@ module Brancher
   module DatabaseRenameService
     extend self
 
-    def rename!(configurations)
-      configuration = configurations[env]
+    def rename!(configurations, key = env)
+      configuration = configurations[key]
       configuration["original_database"] = configuration["database"]
       configuration["database"] = database_name_with_suffix(configuration["database"])
       configurations

--- a/lib/brancher/multiple_database_configuration_renaming.rb
+++ b/lib/brancher/multiple_database_configuration_renaming.rb
@@ -1,0 +1,15 @@
+module Brancher
+  module MultipleDatabaseConfigurationRenaming
+    module ClassMethods
+      def establish_connection(spec = nil)
+        DatabaseRenameService.rename!(configurations, spec.to_s) if spec && spec.is_a?(Hash).!
+
+        super
+      end
+    end
+
+    def self.prepended(base)
+      base.singleton_class.send(:prepend, ClassMethods)
+    end
+  end
+end

--- a/lib/brancher/railtie.rb
+++ b/lib/brancher/railtie.rb
@@ -4,6 +4,7 @@ module Brancher
   class Railtie < Rails::Railtie
     initializer "brancher.rename_database", before: "active_record.initialize_database" do
       Rails::Application::Configuration.send(:prepend, DatabaseConfigurationRenaming)
+      ActiveRecord::Base.send(:prepend, MultipleDatabaseConfigurationRenaming)
       ActiveRecord::ConnectionAdapters::ConnectionPool.send(:prepend, AutoCopying)
     end
 

--- a/spec/brancher/database_rename_service_spec.rb
+++ b/spec/brancher/database_rename_service_spec.rb
@@ -97,5 +97,29 @@ describe Brancher::DatabaseRenameService do
 
       it { is_expected.to eq new_configurations }
     end
+
+    context "when it connect another database" do
+      let(:adapter) do
+        "mysql2"
+      end
+
+      let(:database_name) do
+        "sample_app_another_db"
+      end
+
+      let(:new_database_name) do
+        "#{database_name}_#{branch}"
+      end
+
+      let(:env) do
+        "another_db"
+      end
+
+      subject do
+        Brancher::DatabaseRenameService.rename!(configurations, env)
+      end
+
+      it { is_expected.to eq new_configurations }
+    end
   end
 end


### PR DESCRIPTION
This PR will supports multiple database.

It will rename the database name when `ActiveRecord::Base.establish_connection` is called .
